### PR TITLE
fix daostar link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DAOstar: DAO Standards
 
-This repo contains the website for [daostar.org](daostar.org) as well as reference implementations, schemas, and other assets related to EIP-4824 Decentralized Autonomous Organizations.
+This repo contains the website for [daostar.org](https://daostar.org) as well as reference implementations, schemas, and other assets related to EIP-4824 Decentralized Autonomous Organizations.
 
 It is maintained by [DAOstar One](https://daostar.one) with support from Metagov (https://metagov.org).


### PR DESCRIPTION
current link (without `https`) points to https://github.com/metagov/daostar.../daostar.org.  adding the https fixes the link.