### PR TITLE
Update homepage with a link to DAOIPs

### DIFF
--- a/daostar-website/src/components/Homepage/Homepage.js
+++ b/daostar-website/src/components/Homepage/Homepage.js
@@ -149,13 +149,13 @@ const Homepage = (props) => {
                             <div className='sidebar one-third'>
                                 <div className='button-info-group'>
                                     <a 
-                                        href="https://discord.com/invite/PdrPkEZVFk" 
+                                        href="https://github.com/metagov/daostar/discussions" 
                                         target="_blank"
                                         className="btn"
                                     >
-                                        Join our Discord
+                                        DAOIPs
                                     </a>
-                                    <p>For questions and discussion, go to #daostar or #daostar-one.</p>
+                                    <p>Join the forum to submit and discuss DAOIPs</p>
                                 </div>
                                 <div className='button-info-group'>
                                     <a 


### PR DESCRIPTION
Replaced an existing button that lead to the DAOstar discord with one that leads to DAOIPs; changed the discription.