### PR TITLE
Hide Enter Contract Address Field for Custom Framework

### DIFF
--- a/daostar-website/src/components/Register/RegistrationForm/RegistrationForm.js
+++ b/daostar-website/src/components/Register/RegistrationForm/RegistrationForm.js
@@ -1,4 +1,5 @@
 import React, { Fragment, useEffect, useState } from 'react'
+
 import validator from 'validator'
 import useAxios from 'axios-hooks'
 import { Button, Callout, Divider, FormGroup, HTMLSelect, InputGroup } from '@blueprintjs/core'
@@ -262,6 +263,7 @@ const RegistrationForm = ({ toggleRegScreen, setRegistrationData }) => {
                     placeholder="Enter DAO address or id (eg ENS for snapshot)"
                     value={daoContractAddress}
                     onChange={onChangeDaoContractAddress}
+                    disabled={ daoFramework !== 'custom' ? false : true}
                 />
             </div>
             <div className="wizard-row">


### PR DESCRIPTION
**Summary:**
Solving this issue https://github.com/metagov/daostar/issues/130

- Hide Enter Contract Address Field for Custom Framework as it is unnecessary. Contract Address would be derived from the DAO Registration transaction by default. However, it is required for other frameworks as we need to generate the Members and other URIs

**Demo Images**
![image](https://github.com/metagov/daostar/assets/41290852/b9fd76ea-59a6-4912-9a22-c6a1ccdbd011)
![image](https://github.com/metagov/daostar/assets/41290852/f2d854bf-6996-40c3-a74b-993a939fff9e)
![image](https://github.com/metagov/daostar/assets/41290852/f2a2c4a0-5ff1-418f-984b-c96866119263)
